### PR TITLE
Implement database migrations workflow

### DIFF
--- a/.github/workflows/deploy-react.yml
+++ b/.github/workflows/deploy-react.yml
@@ -59,22 +59,18 @@ jobs:
             echo "⚠️ No existing database to backup (fresh install)"
           fi
 
-      - name: Sync database schema
+      - name: Run database migrations
         run: |
           BUILD_DIR="$BASE/builds/${{ github.run_id }}"
           cd "$BUILD_DIR"
           
-          # Push schema with --strict to require confirmation for destructive changes
-          # In CI, this will fail if there are data-loss statements, alerting us to review
-          DATABASE_URL="$DATABASE_URL" bunx drizzle-kit push --strict 2>&1 || {
-            echo "❌ Schema push failed - may require manual migration review"
-            echo "Check the destructive statements and create explicit migrations if needed"
-            exit 1
-          }
+          # Apply committed migration files (safe, deterministic)
+          # Fails if no migration files exist for pending schema changes
+          DATABASE_URL="$DATABASE_URL" bun run db:migrate
           
           # Checkpoint WAL and release locks before build
           sqlite3 "$DATABASE_URL" "PRAGMA wal_checkpoint(TRUNCATE);" 2>/dev/null || true
-          echo "✅ Schema sync complete"
+          echo "✅ Migrations applied"
 
       - name: Build application
         run: |

--- a/rubigo-react/.agent/workflows/migrations.md
+++ b/rubigo-react/.agent/workflows/migrations.md
@@ -1,0 +1,91 @@
+---
+description: How to create and deploy database schema migrations
+---
+
+# Database Migrations
+
+Follow this workflow when making changes to the database schema.
+
+## When to Use
+
+Use this workflow when you modify any file in `src/db/schema.ts`.
+
+## Step 1: Modify the Schema
+
+Edit `src/db/schema.ts` with your changes (add tables, columns, etc.).
+
+## Step 2: Generate Migration
+
+// turbo
+From `rubigo-react/`:
+```bash
+bun run db:generate
+```
+
+This creates a new migration file in `drizzle/` like `0001_descriptive_name.sql`.
+
+## Step 3: Review the Migration
+
+Open the generated SQL file and verify:
+- The SQL is correct
+- No unexpected DROP statements
+- Data will be preserved
+
+> [!CAUTION]
+> Destructive operations (DROP COLUMN, DROP TABLE) will cause data loss in production. If you see these, consider if they're intentional.
+
+## Step 4: Test Locally
+
+// turbo
+Apply the migration to your local database:
+```bash
+bun run db:migrate
+```
+
+Verify the application still works:
+```bash
+bun run dev
+```
+
+## Step 5: Commit Migration Files
+
+Include **both** the schema change and migration file:
+```bash
+git add src/db/schema.ts
+git add drizzle/
+git commit -m "feat(db): add xyz column to users table"
+```
+
+> [!IMPORTANT]
+> Never commit schema changes without the corresponding migration file. The deploy workflow will fail if migrations are missing.
+
+## How It Works
+
+| Environment | Command | Behavior |
+|-------------|---------|----------|
+| **Local dev** | `db:push` | Direct sync (fast iteration) |
+| **Production** | `db:migrate` | File-based migrations only |
+
+This ensures production only applies reviewed, committed migrations.
+
+## Troubleshooting
+
+### Migration fails in CI
+
+The production database is behind. Options:
+1. Check if migration file was committed
+2. Verify migration order is correct
+3. Check for conflicts with existing data
+
+### Need to modify a migration
+
+If the migration hasn't been deployed yet:
+```bash
+# Delete the migration file
+rm drizzle/XXXX_name.sql
+
+# Regenerate
+bun run db:generate
+```
+
+If the migration has been deployed, create a new migration instead.

--- a/rubigo-react/.agent/workflows/publish.md
+++ b/rubigo-react/.agent/workflows/publish.md
@@ -55,14 +55,29 @@ version = "x.y.z"
 > [!TIP]
 > A change is **breaking** if existing E2E tests had to be modified to pass (not just new tests added).
 
-## Step 3: Build Verification
+## Step 3: Check Database Migrations
+
+If you modified `src/db/schema.ts`, ensure migrations are generated:
+
+// turbo
+```bash
+# Check for uncommitted schema changes
+bun run db:generate
+```
+
+If new migration files were created, commit them with your schema changes. See `/migrations` workflow for details.
+
+> [!IMPORTANT]
+> Production deployments use `db:migrate`, not `db:push`. Changes without migrations will not be applied.
+
+## Step 4: Build Verification
 
 // turbo
 ```
 bun run build
 ```
 
-## Step 4: Run Unit Tests
+## Step 5: Run Unit Tests
 
 // turbo
 ```
@@ -72,7 +87,7 @@ bun test
 > [!NOTE]
 > E2E tests are run separately using the `/e2e` workflow or `bun run test:e2e:full`.
 
-## Step 5: Commit and Push
+## Step 6: Commit and Push
 
 Commit with a conventional commit message:
 ```

--- a/rubigo-react/.agent/workflows/wip-publish.md
+++ b/rubigo-react/.agent/workflows/wip-publish.md
@@ -59,7 +59,25 @@ This checks for:
 
 If errors are found, fix them before proceeding. Warnings require explicit user approval.
 
-## Step 4: Run E2E Tests
+## Step 4: Check Database Migrations
+
+If `src/db/schema.ts` was modified, generate and commit migrations:
+
+// turbo
+```bash
+bun run db:generate
+```
+
+If new migration files were created in `drizzle/`, commit them:
+```bash
+git add drizzle/
+git commit -m "feat(db): add migration for schema changes"
+```
+
+> [!IMPORTANT]
+> Production uses `db:migrate`. Schema changes without migrations will not be deployed.
+
+## Step 5: Run E2E Tests
 
 // turbo
 Follow the `/e2e` workflow or run directly:
@@ -67,7 +85,7 @@ Follow the `/e2e` workflow or run directly:
 bun run test:e2e:full
 ```
 
-## Step 5: Version Bump
+## Step 6: Version Bump
 
 > [!IMPORTANT]
 > This step is **REQUIRED** for every merge to main.
@@ -103,7 +121,7 @@ git add rubigo.toml
 git commit --amend --no-edit
 ```
 
-## Step 6: Push Changes
+## Step 7: Push Changes
 
 Push the rebased branch (force-with-lease is safe after rebase):
 ```bash
@@ -113,7 +131,7 @@ git push --force-with-lease
 > [!NOTE]
 > `--force-with-lease` fails if someone else pushed since your last fetch.
 
-## Step 7: Ensure PR Exists
+## Step 8: Ensure PR Exists
 
 If no PR exists yet, create one:
 ```
@@ -136,7 +154,7 @@ mcp_github-mcp-server_update_pull_request
   draft: false
 ```
 
-## Step 8: Merge PR
+## Step 9: Merge PR
 
 Use GitHub MCP:
 ```
@@ -147,7 +165,7 @@ mcp_github-mcp-server_merge_pull_request
   merge_method: squash
 ```
 
-## Step 9: Cleanup
+## Step 10: Cleanup
 
 From the main repo checkout (not the worktree):
 ```bash
@@ -164,7 +182,7 @@ git push origin --delete <type>/<slug>
 git fetch --prune
 ```
 
-## Step 10: Sync Main
+## Step 11: Sync Main
 
 Update the main checkout with merged changes:
 ```bash
@@ -176,6 +194,7 @@ git pull
 
 Before merging, ensure:
 - [ ] Pre-push validation passed (no errors)
+- [ ] Database migrations generated (if schema changed)
 - [ ] E2E tests passed (or failures are pre-existing)
 - [ ] Version bumped in `rubigo.toml`
 - [ ] Commit message follows conventional format

--- a/rubigo-react/rubigo.toml
+++ b/rubigo-react/rubigo.toml
@@ -1,4 +1,4 @@
 [app]
 name = "Rubigo"
-version = "0.1.7"
+version = "0.1.8"
 description = "Enterprise Resource Management Platform"


### PR DESCRIPTION
## Summary

Implements a robust database migrations workflow to prevent data loss during production deployments.

## Changes

- **Deploy workflow**: Uses `db:migrate` instead of `push` - only applies committed migrations
- **New `/migrations` workflow**: Documents how to create and deploy schema changes
- **Updated `/publish` and `/wip-publish`**: Added migration check steps

## Why

`drizzle-kit push` could silently accept destructive schema changes in CI, causing data loss. File-based migrations are safer because:
- Only committed, reviewed changes are applied
- Failures are predictable (missing migration = deploy fails)
- No auto-acceptance of destructive operations

## Version

0.1.7 → 0.1.8 (patch for chore/docs changes)