### PR TITLE
fix(deploy): preserve production database across deployments

### DIFF
--- a/.github/workflows/deploy-react.yml
+++ b/.github/workflows/deploy-react.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Preserve gitignored files (like production/rubigo-react/data/rubigo.db)
+          # between deployments. Default 'clean: true' runs git clean -ffdx which
+          # deletes untracked files, causing the production database to be wiped.
+          clean: false
 
       - name: Prepare build directory
         run: |

--- a/rubigo-react/rubigo.toml
+++ b/rubigo-react/rubigo.toml
@@ -1,4 +1,4 @@
 [app]
 name = "Rubigo"
-version = "0.2.0"
+version = "0.2.1"
 description = "Enterprise Resource Management Platform"


### PR DESCRIPTION
## Problem

When deploying to production, the instance reverts to the initialization phase, requiring the Global Administrator to be recreated.

## Root Cause

The `actions/checkout@v4` action runs with `clean: true` by default, which executes `git clean -ffdx && git reset --hard HEAD` before fetching. This deletes all untracked files, including the gitignored production database at:

```
production/rubigo-react/data/rubigo.db
```

Since the database contains the Global Administrator record that determines initialization status, deleting it causes the system to show the initialization form again.

## Fix

Set `clean: false` in the checkout step to preserve untracked/gitignored files between deployments.

## Testing

After merging, verify that a subsequent deployment:
1. Does **not** show "INITIALIZATION REQUIRED" in stdout.log
2. Preserves the existing Global Administrator and data