### PR TITLE
feat: add ABAC schema foundation and decision algorithm

### DIFF
--- a/common/scenarios/mmc/access-control.toml
+++ b/common/scenarios/mmc/access-control.toml
@@ -1,0 +1,472 @@
+# ============================================================================
+# RUBIGO ACCESS CONTROL - Requirements Ontology
+# ============================================================================
+# This file contains requirements for the Attribute-Based Access Control (ABAC)
+# module, following the Requirements & Delivery Ontology.
+
+[description]
+overview = """
+ACCESS CONTROL REQUIREMENTS
+- Implements ABAC (Attribute-Based Access Control) for all platform data
+- Three-dimensional access model: Sensitivity, Tenant, Role
+- Dual-column schema: ACO (indexed) and SCO (metadata)
+- Unified processing stack for all CRUD operations
+- Comprehensive audit logging for all data access
+
+This module ensures uniform data access control across the Rubigo platform,
+laying the foundation for enterprise security posture.
+"""
+
+# ============================================================================
+# OBJECTIVES - Strategic goals for access control
+# ============================================================================
+
+[[objectives]]
+id = "obj-rubigo-access"
+title = "Attribute-Based Access Control"
+description = "The platform must enforce fine-grained access control where data visibility is determined by subject attributes (clearance, tenants, roles) evaluated against object attributes (sensitivity, tenants, required roles)"
+project_id = "d4e5f6"
+parent_id = "obj-it-security"
+status = "active"
+
+[[objectives]]
+id = "obj-rubigo-sensitivity"
+title = "Sensitivity Classification"
+description = "All platform data must be classified by sensitivity level (public, low, moderate, high), and users must have appropriate clearance to access data at each level"
+project_id = "d4e5f6"
+parent_id = "obj-rubigo-access"
+status = "active"
+
+[[objectives]]
+id = "obj-rubigo-tenants"
+title = "Tenant Compartmentalization"
+description = "Sensitive programs or compartments (represented by fruit emojis) can be assigned to data, and users must have specific tenant access at the appropriate sensitivity level"
+project_id = "d4e5f6"
+parent_id = "obj-rubigo-access"
+status = "active"
+
+[[objectives]]
+id = "obj-rubigo-roles"
+title = "Role-Based Access Constraints"
+description = "Data can require specific roles for access, and users must possess all required roles to view or modify that data"
+project_id = "d4e5f6"
+parent_id = "obj-rubigo-access"
+status = "active"
+
+[[objectives]]
+id = "obj-rubigo-audit"
+title = "Comprehensive Access Audit"
+description = "All data access operations (create, read, update, delete) must be logged with subject, object, action, and outcome for security auditing"
+project_id = "d4e5f6"
+parent_id = "obj-rubigo-access"
+status = "active"
+
+[[objectives]]
+id = "obj-rubigo-classification"
+title = "Classification Guidance"
+description = "The platform must provide classification guides that help users understand how to correctly classify data by sensitivity, tenant, and role requirements"
+project_id = "d4e5f6"
+parent_id = "obj-rubigo-access"
+status = "active"
+
+# ============================================================================
+# FEATURES - Capabilities that realize access control objectives
+# ============================================================================
+
+[[features]]
+id = "feat-aco-schema"
+name = "Access Control Object Schema"
+description = "Every data table has an ACO (indexed JSON) and SCO (metadata JSON) column for access control"
+objective_id = "obj-rubigo-access"
+status = "planned"
+
+[[features]]
+id = "feat-sensitivity-levels"
+name = "Sensitivity Level Enforcement"
+description = "Users can only access data with sensitivity at or below their clearance level"
+objective_id = "obj-rubigo-sensitivity"
+status = "planned"
+
+[[features]]
+id = "feat-tenant-access"
+name = "Tenant Compartment Enforcement"
+description = "Users can only access data in tenants they have been granted access to at the appropriate level"
+objective_id = "obj-rubigo-tenants"
+status = "planned"
+
+[[features]]
+id = "feat-role-requirements"
+name = "Role Requirement Enforcement"
+description = "Users must have all required roles to access data that specifies role requirements"
+objective_id = "obj-rubigo-roles"
+status = "planned"
+
+[[features]]
+id = "feat-access-logging"
+name = "Access Logging"
+description = "All data access operations are logged with full context for audit purposes"
+objective_id = "obj-rubigo-audit"
+status = "planned"
+
+[[features]]
+id = "feat-classification-guides"
+name = "Classification Guide Management"
+description = "Administrators can create and manage classification guides that provide English-level descriptions of how to classify data"
+objective_id = "obj-rubigo-classification"
+status = "planned"
+
+[[features]]
+id = "feat-aco-modification"
+name = "ACO Modification"
+description = "Users can modify the access control settings of records they can access, within their clearance limits"
+objective_id = "obj-rubigo-access"
+status = "planned"
+
+# ============================================================================
+# RULES - User stories for access control features
+# ============================================================================
+
+# --- ACO Schema Rules ---
+
+[[rules]]
+id = "rule-aco-default"
+feature_id = "feat-aco-schema"
+role = "Platform System"
+requirement = "assign a default ACO to every new record"
+reason = "ensure no data is created without access control"
+status = "draft"
+
+[[rules]]
+id = "rule-aco-explicit"
+feature_id = "feat-aco-schema"
+role = "Platform System"
+requirement = "store each object's ACO explicitly (no inheritance)"
+reason = "ensure access control is unambiguous and auditable"
+status = "draft"
+
+# --- Sensitivity Level Rules ---
+
+[[rules]]
+id = "rule-sensitivity-view"
+feature_id = "feat-sensitivity-levels"
+role = "Platform User"
+requirement = "only see records with sensitivity at or below my clearance level"
+reason = "prevent unauthorized access to sensitive information"
+status = "draft"
+
+[[rules]]
+id = "rule-sensitivity-create"
+feature_id = "feat-sensitivity-levels"
+role = "Platform User"
+requirement = "create records with sensitivity at or below my clearance level"
+reason = "prevent escalation of data sensitivity beyond my authorization"
+status = "draft"
+
+[[rules]]
+id = "rule-sensitivity-indicator"
+feature_id = "feat-sensitivity-levels"
+role = "Platform User"
+requirement = "see a visual indicator of each record's sensitivity level"
+reason = "understand the classification of data I'm viewing"
+status = "draft"
+
+# --- Tenant Access Rules ---
+
+[[rules]]
+id = "rule-tenant-access"
+feature_id = "feat-tenant-access"
+role = "Platform User"
+requirement = "only see records in tenants I have access to at the appropriate level"
+reason = "maintain compartmentalization of sensitive programs"
+status = "draft"
+
+[[rules]]
+id = "rule-tenant-multi"
+feature_id = "feat-tenant-access"
+role = "Platform User"
+requirement = "access records that require multiple tenants only if I have access to all of them"
+reason = "enforce the principle of least privilege across compartments"
+status = "draft"
+
+[[rules]]
+id = "rule-tenant-indicator"
+feature_id = "feat-tenant-access"
+role = "Platform User"
+requirement = "see tenant indicators (fruit emojis) on records that are compartmentalized"
+reason = "understand which sensitive programs protect the data"
+status = "draft"
+
+# --- Role Requirement Rules ---
+
+[[rules]]
+id = "rule-role-access"
+feature_id = "feat-role-requirements"
+role = "Platform User"
+requirement = "only see records requiring roles I possess"
+reason = "enforce function-based access control"
+status = "draft"
+
+[[rules]]
+id = "rule-role-multi"
+feature_id = "feat-role-requirements"
+role = "Platform User"
+requirement = "access records requiring multiple roles only if I have all specified roles"
+reason = "ensure data is only visible to those with complete authorization"
+status = "draft"
+
+[[rules]]
+id = "rule-global-admin"
+feature_id = "feat-role-requirements"
+role = "Global Administrator"
+requirement = "bypass all access control checks"
+reason = "administer the platform without restrictions"
+status = "draft"
+
+# --- Access Logging Rules ---
+
+[[rules]]
+id = "rule-log-all-reads"
+feature_id = "feat-access-logging"
+role = "Platform System"
+requirement = "log every data read operation with subject, object, and timestamp"
+reason = "maintain complete audit trail for security review"
+status = "draft"
+
+[[rules]]
+id = "rule-log-writes"
+feature_id = "feat-access-logging"
+role = "Platform System"
+requirement = "log every data write operation with subject, object, changes, and timestamp"
+reason = "track all modifications for accountability"
+status = "draft"
+
+[[rules]]
+id = "rule-log-denials"
+feature_id = "feat-access-logging"
+role = "Platform System"
+requirement = "log every access denial with subject, attempted action, and reason"
+reason = "detect potential security incidents and policy violations"
+status = "draft"
+
+# --- Classification Guide Rules ---
+
+[[rules]]
+id = "rule-guide-create"
+feature_id = "feat-classification-guides"
+role = "Platform Administrator"
+requirement = "create classification guides with English descriptions for each sensitivity level"
+reason = "help users correctly classify data"
+status = "draft"
+
+[[rules]]
+id = "rule-guide-reference"
+feature_id = "feat-classification-guides"
+role = "Platform User"
+requirement = "see which classification guides apply to a record's classification"
+reason = "understand why data is classified at a particular level"
+status = "draft"
+
+[[rules]]
+id = "rule-guide-tenant"
+feature_id = "feat-classification-guides"
+role = "Platform Administrator"
+requirement = "include tenant-specific guidance in classification guides"
+reason = "clarify when data should be compartmentalized"
+status = "draft"
+
+# --- ACO Modification Rules ---
+
+[[rules]]
+id = "rule-aco-modify-allowed"
+feature_id = "feat-aco-modification"
+role = "Platform User"
+requirement = "modify the ACO of records I can access to other ACOs I would also be able to access"
+reason = "adjust classification as data sensitivity changes"
+status = "draft"
+
+[[rules]]
+id = "rule-aco-modify-log"
+feature_id = "feat-aco-modification"
+role = "Platform System"
+requirement = "log all ACO modifications with before/after values"
+reason = "track classification changes for audit"
+status = "draft"
+
+# ============================================================================
+# SCENARIOS - Test cases for access control rules
+# ============================================================================
+
+# --- Default ACO Scenarios ---
+
+[[scenarios]]
+id = "scen-aco-default-create"
+rule_id = "rule-aco-default"
+name = "New record gets default ACO"
+narrative = "Given I create a new personnel record, when I do not specify an ACO, then the record is saved with ACO {\"sensitivity\": \"low\"}"
+status = "draft"
+
+[[scenarios]]
+id = "scen-aco-explicit-no-inherit"
+rule_id = "rule-aco-explicit"
+name = "Child records do not inherit parent ACO"
+narrative = "Given a chat channel has ACO {\"sensitivity\": \"moderate\"}, when I send a message to that channel without specifying ACO, then the message gets the default ACO {\"sensitivity\": \"low\"}, not the channel's ACO"
+status = "draft"
+
+# --- Sensitivity Level Scenarios ---
+
+[[scenarios]]
+id = "scen-sensitivity-filter-list"
+rule_id = "rule-sensitivity-view"
+name = "List filtered by sensitivity"
+narrative = "Given I have clearance 'moderate' and there are personnel records at public, low, moderate, and high sensitivity, when I list personnel, then I only see records with sensitivity public, low, or moderate"
+status = "draft"
+
+[[scenarios]]
+id = "scen-sensitivity-block-detail"
+rule_id = "rule-sensitivity-view"
+name = "Cannot view high sensitivity record"
+narrative = "Given I have clearance 'moderate' and a personnel record has sensitivity 'high', when I try to view that record by ID, then I receive an access denied response"
+status = "draft"
+
+[[scenarios]]
+id = "scen-sensitivity-create-blocked"
+rule_id = "rule-sensitivity-create"
+name = "Cannot create above clearance"
+narrative = "Given I have clearance 'moderate', when I try to create a record with sensitivity 'high', then the creation fails with an access denied error"
+status = "draft"
+
+[[scenarios]]
+id = "scen-sensitivity-badge"
+rule_id = "rule-sensitivity-indicator"
+name = "Sensitivity badge displayed"
+narrative = "Given I am viewing a personnel detail panel, when the record has sensitivity 'moderate', then I see a visual badge indicating 'MODERATE' classification"
+status = "draft"
+
+# --- Tenant Access Scenarios ---
+
+[[scenarios]]
+id = "scen-tenant-single-access"
+rule_id = "rule-tenant-access"
+name = "Can access single tenant record"
+narrative = "Given I have tenant access 'moderate:🍎' and a record has tenants ['🍎'] with sensitivity 'low', when I view the record, then I can see it"
+status = "draft"
+
+[[scenarios]]
+id = "scen-tenant-single-blocked"
+rule_id = "rule-tenant-access"
+name = "Blocked without tenant access"
+narrative = "Given I have no tenant access for 🍎 and a record has tenants ['🍎'], when I try to view the record, then I receive an access denied response"
+status = "draft"
+
+[[scenarios]]
+id = "scen-tenant-insufficient-level"
+rule_id = "rule-tenant-access"
+name = "Blocked with insufficient tenant level"
+narrative = "Given I have tenant access 'low:🍎' and a record has tenants ['🍎'] with sensitivity 'moderate', when I try to view the record, then I receive an access denied response"
+status = "draft"
+
+[[scenarios]]
+id = "scen-tenant-multi-all"
+rule_id = "rule-tenant-multi"
+name = "Access requires all tenants"
+narrative = "Given I have tenant access 'moderate:🍎' but not 🍌 and a record has tenants ['🍎', '🍌'], when I try to view the record, then I receive an access denied response"
+status = "draft"
+
+[[scenarios]]
+id = "scen-tenant-emoji-display"
+rule_id = "rule-tenant-indicator"
+name = "Tenant emojis displayed"
+narrative = "Given I am viewing a record with tenants ['🍎', '🍌'], when I look at the record header, then I see the emojis 🍎🍌 displayed as tenant indicators"
+status = "draft"
+
+# --- Role Requirement Scenarios ---
+
+[[scenarios]]
+id = "scen-role-single-access"
+rule_id = "rule-role-access"
+name = "Can access with required role"
+narrative = "Given I have role 'hr_viewer' and a record requires roles ['hr_viewer'], when I view the record, then I can see it"
+status = "draft"
+
+[[scenarios]]
+id = "scen-role-single-blocked"
+rule_id = "rule-role-access"
+name = "Blocked without required role"
+narrative = "Given I do not have role 'hr_viewer' and a record requires roles ['hr_viewer'], when I try to view the record, then I receive an access denied response"
+status = "draft"
+
+[[scenarios]]
+id = "scen-role-multi-partial"
+rule_id = "rule-role-multi"
+name = "Partial roles insufficient"
+narrative = "Given I have role 'manager' but not 'hr_viewer' and a record requires roles ['manager', 'hr_viewer'], when I try to view the record, then I receive an access denied response"
+status = "draft"
+
+[[scenarios]]
+id = "scen-role-global-admin-bypass"
+rule_id = "rule-global-admin"
+name = "Global admin bypasses all checks"
+narrative = "Given I have role 'global_admin' and a record has sensitivity 'high', tenants ['🍎'], and roles ['secret_committee'], when I view the record, then I can see it regardless of my other attributes"
+status = "draft"
+
+# --- Access Logging Scenarios ---
+
+[[scenarios]]
+id = "scen-log-read-recorded"
+rule_id = "rule-log-all-reads"
+name = "Read operation logged"
+narrative = "Given I view a personnel record, when the request completes, then an entry exists in the access log with my subject ID, the record ID, action 'read', and timestamp"
+status = "draft"
+
+[[scenarios]]
+id = "scen-log-write-recorded"
+rule_id = "rule-log-writes"
+name = "Write operation logged with changes"
+narrative = "Given I update a personnel record's title, when the request completes, then an entry exists in the access log with action 'update', old value, new value, and timestamp"
+status = "draft"
+
+[[scenarios]]
+id = "scen-log-denial-recorded"
+rule_id = "rule-log-denials"
+name = "Access denial logged"
+narrative = "Given I try to view a record I cannot access, when the request is denied, then an entry exists in the access log with action 'read', outcome 'denied', and the reason for denial"
+status = "draft"
+
+# --- Classification Guide Scenarios ---
+
+[[scenarios]]
+id = "scen-guide-create"
+rule_id = "rule-guide-create"
+name = "Create classification guide"
+narrative = "Given I am a Global Administrator, when I create a classification guide with descriptions for each sensitivity level, then the guide is saved and available for reference"
+status = "draft"
+
+[[scenarios]]
+id = "scen-guide-referenced"
+rule_id = "rule-guide-reference"
+name = "View classification guide reference"
+narrative = "Given a record's SCO references classification guide 'CG-HR-001', when I view the record's security context, then I can see the guide ID and click to view its full content"
+status = "draft"
+
+# --- ACO Modification Scenarios ---
+
+[[scenarios]]
+id = "scen-aco-modify-within-clearance"
+rule_id = "rule-aco-modify-allowed"
+name = "Can modify ACO within clearance"
+narrative = "Given I have clearance 'moderate' and a record has sensitivity 'low', when I change the sensitivity to 'moderate', then the change is saved successfully"
+status = "draft"
+
+[[scenarios]]
+id = "scen-aco-modify-blocked"
+rule_id = "rule-aco-modify-allowed"
+name = "Cannot modify ACO beyond clearance"
+narrative = "Given I have clearance 'moderate' and a record has sensitivity 'low', when I try to change the sensitivity to 'high', then the change is rejected with an access denied error"
+status = "draft"
+
+[[scenarios]]
+id = "scen-aco-modify-logged"
+rule_id = "rule-aco-modify-log"
+name = "ACO modification logged"
+narrative = "Given I modify a record's sensitivity from 'low' to 'moderate', when the change is saved, then an entry exists in the access log with action 'aco_modify', old ACO, new ACO, and my subject ID"
+status = "draft"

--- a/rubigo-react/rubigo.toml
+++ b/rubigo-react/rubigo.toml
@@ -1,4 +1,4 @@
 [app]
 name = "Rubigo"
-version = "0.8.0"
+version = "0.9.0"
 description = "Enterprise Resource Management Platform"

--- a/rubigo-react/src/__tests__/access-control/decision.test.ts
+++ b/rubigo-react/src/__tests__/access-control/decision.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Access Control Decision Algorithm Tests
+ *
+ * Tests for canAccess() and canModifyACO() functions.
+ * Test cases correspond to scenarios in access-control.toml.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+    canAccess,
+    canModifyACO,
+    filterByAccess,
+} from "@/lib/access-control/decision";
+import type { AccessControlObject, Subject } from "@/lib/access-control/types";
+import { createTestSubject } from "@/lib/access-control/session-resolver";
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function makeSubject(overrides: Partial<Subject> = {}): Subject {
+    return createTestSubject(overrides);
+}
+
+function makeACO(overrides: Partial<AccessControlObject> = {}): AccessControlObject {
+    return {
+        sensitivity: "low",
+        ...overrides,
+    };
+}
+
+// ============================================================================
+// Global Admin Bypass
+// ============================================================================
+
+describe("Global Admin Bypass", () => {
+    it("scen-role-global-admin-bypass: bypasses all checks", () => {
+        const subject = makeSubject({
+            roles: ["global_admin"],
+            clearanceLevel: "public", // Even with lowest clearance
+        });
+
+        const aco = makeACO({
+            sensitivity: "high",
+            tenants: ["🍎"],
+            roles: ["secret_committee"],
+        });
+
+        const result = canAccess(subject, aco);
+        expect(result.permitted).toBe(true);
+    });
+});
+
+// ============================================================================
+// Sensitivity Level Tests
+// ============================================================================
+
+describe("Sensitivity Level", () => {
+    it("scen-sensitivity-filter-list: can access at or below clearance", () => {
+        const subject = makeSubject({ clearanceLevel: "moderate" });
+
+        expect(canAccess(subject, makeACO({ sensitivity: "public" })).permitted).toBe(true);
+        expect(canAccess(subject, makeACO({ sensitivity: "low" })).permitted).toBe(true);
+        expect(canAccess(subject, makeACO({ sensitivity: "moderate" })).permitted).toBe(true);
+    });
+
+    it("scen-sensitivity-block-detail: cannot access above clearance", () => {
+        const subject = makeSubject({ clearanceLevel: "moderate" });
+        const aco = makeACO({ sensitivity: "high" });
+
+        const result = canAccess(subject, aco);
+        expect(result.permitted).toBe(false);
+        expect(result.failedCheck).toBe("sensitivity");
+        expect(result.reason).toContain("requires 'high'");
+    });
+
+    it("scen-sensitivity-create-blocked: test sensitivity ordering", () => {
+        const subject = makeSubject({ clearanceLevel: "low" });
+
+        expect(canAccess(subject, makeACO({ sensitivity: "public" })).permitted).toBe(true);
+        expect(canAccess(subject, makeACO({ sensitivity: "low" })).permitted).toBe(true);
+        expect(canAccess(subject, makeACO({ sensitivity: "moderate" })).permitted).toBe(false);
+        expect(canAccess(subject, makeACO({ sensitivity: "high" })).permitted).toBe(false);
+    });
+});
+
+// ============================================================================
+// Tenant Access Tests
+// ============================================================================
+
+describe("Tenant Access", () => {
+    it("scen-tenant-single-access: can access with tenant clearance", () => {
+        const subject = makeSubject({
+            clearanceLevel: "moderate",
+            tenantClearances: ["moderate:🍎"],
+        });
+
+        const aco = makeACO({
+            sensitivity: "low",
+            tenants: ["🍎"],
+        });
+
+        expect(canAccess(subject, aco).permitted).toBe(true);
+    });
+
+    it("scen-tenant-single-blocked: blocked without tenant access", () => {
+        const subject = makeSubject({
+            clearanceLevel: "moderate",
+            tenantClearances: [], // No tenant access
+        });
+
+        const aco = makeACO({
+            sensitivity: "low",
+            tenants: ["🍎"],
+        });
+
+        const result = canAccess(subject, aco);
+        expect(result.permitted).toBe(false);
+        expect(result.failedCheck).toBe("tenant");
+        expect(result.reason).toContain("No access to tenant '🍎'");
+    });
+
+    it("scen-tenant-insufficient-level: blocked with insufficient tenant level", () => {
+        const subject = makeSubject({
+            clearanceLevel: "moderate",
+            tenantClearances: ["low:🍎"], // Only low clearance for 🍎
+        });
+
+        const aco = makeACO({
+            sensitivity: "moderate", // Requires moderate
+            tenants: ["🍎"],
+        });
+
+        const result = canAccess(subject, aco);
+        expect(result.permitted).toBe(false);
+        expect(result.failedCheck).toBe("tenant");
+        expect(result.reason).toContain("Insufficient tenant clearance");
+    });
+
+    it("scen-tenant-multi-all: access requires ALL tenants", () => {
+        const subject = makeSubject({
+            clearanceLevel: "moderate",
+            tenantClearances: ["moderate:🍎"], // Only 🍎, not 🍌
+        });
+
+        const aco = makeACO({
+            sensitivity: "low",
+            tenants: ["🍎", "🍌"], // Requires both
+        });
+
+        const result = canAccess(subject, aco);
+        expect(result.permitted).toBe(false);
+        expect(result.failedCheck).toBe("tenant");
+    });
+
+    it("can access with all required tenants", () => {
+        const subject = makeSubject({
+            clearanceLevel: "high",
+            tenantClearances: ["high:🍎", "high:🍌"],
+        });
+
+        const aco = makeACO({
+            sensitivity: "moderate",
+            tenants: ["🍎", "🍌"],
+        });
+
+        expect(canAccess(subject, aco).permitted).toBe(true);
+    });
+
+    it("null tenants means no tenant restriction", () => {
+        const subject = makeSubject({
+            clearanceLevel: "moderate",
+            tenantClearances: [], // No tenant access
+        });
+
+        const aco = makeACO({
+            sensitivity: "low",
+            // No tenants field - should be accessible
+        });
+
+        expect(canAccess(subject, aco).permitted).toBe(true);
+    });
+});
+
+// ============================================================================
+// Role Requirement Tests
+// ============================================================================
+
+describe("Role Requirements", () => {
+    it("scen-role-single-access: can access with required role", () => {
+        const subject = makeSubject({
+            roles: ["employee", "hr_viewer"],
+        });
+
+        const aco = makeACO({
+            roles: ["hr_viewer"],
+        });
+
+        expect(canAccess(subject, aco).permitted).toBe(true);
+    });
+
+    it("scen-role-single-blocked: blocked without required role", () => {
+        const subject = makeSubject({
+            roles: ["employee"], // No hr_viewer
+        });
+
+        const aco = makeACO({
+            roles: ["hr_viewer"],
+        });
+
+        const result = canAccess(subject, aco);
+        expect(result.permitted).toBe(false);
+        expect(result.failedCheck).toBe("role");
+        expect(result.reason).toContain("Missing required role: 'hr_viewer'");
+    });
+
+    it("scen-role-multi-partial: partial roles insufficient", () => {
+        const subject = makeSubject({
+            roles: ["manager"], // Has manager, but not hr_viewer
+        });
+
+        const aco = makeACO({
+            roles: ["manager", "hr_viewer"], // Requires both
+        });
+
+        const result = canAccess(subject, aco);
+        expect(result.permitted).toBe(false);
+        expect(result.failedCheck).toBe("role");
+    });
+
+    it("can access with all required roles", () => {
+        const subject = makeSubject({
+            roles: ["manager", "hr_viewer", "employee"],
+        });
+
+        const aco = makeACO({
+            roles: ["manager", "hr_viewer"],
+        });
+
+        expect(canAccess(subject, aco).permitted).toBe(true);
+    });
+
+    it("null roles means no role restriction", () => {
+        const subject = makeSubject({
+            roles: ["employee"],
+        });
+
+        const aco = makeACO({
+            // No roles field - should be accessible
+        });
+
+        expect(canAccess(subject, aco).permitted).toBe(true);
+    });
+});
+
+// ============================================================================
+// Combined Checks
+// ============================================================================
+
+describe("Combined Access Checks", () => {
+    it("passes all three dimensions", () => {
+        const subject = makeSubject({
+            clearanceLevel: "high",
+            tenantClearances: ["high:🍎"],
+            roles: ["hr_viewer", "manager"],
+        });
+
+        const aco = makeACO({
+            sensitivity: "moderate",
+            tenants: ["🍎"],
+            roles: ["hr_viewer"],
+        });
+
+        expect(canAccess(subject, aco).permitted).toBe(true);
+    });
+
+    it("fails on sensitivity even with valid tenants and roles", () => {
+        const subject = makeSubject({
+            clearanceLevel: "low", // Too low
+            tenantClearances: ["high:🍎"],
+            roles: ["hr_viewer"],
+        });
+
+        const aco = makeACO({
+            sensitivity: "high",
+            tenants: ["🍎"],
+            roles: ["hr_viewer"],
+        });
+
+        const result = canAccess(subject, aco);
+        expect(result.permitted).toBe(false);
+        expect(result.failedCheck).toBe("sensitivity");
+    });
+
+    it("fails on tenant even with valid sensitivity and roles", () => {
+        const subject = makeSubject({
+            clearanceLevel: "high",
+            tenantClearances: [], // Missing tenant
+            roles: ["hr_viewer"],
+        });
+
+        const aco = makeACO({
+            sensitivity: "low",
+            tenants: ["🍎"],
+            roles: ["hr_viewer"],
+        });
+
+        const result = canAccess(subject, aco);
+        expect(result.permitted).toBe(false);
+        expect(result.failedCheck).toBe("tenant");
+    });
+
+    it("fails on role even with valid sensitivity and tenants", () => {
+        const subject = makeSubject({
+            clearanceLevel: "high",
+            tenantClearances: ["high:🍎"],
+            roles: ["employee"], // Missing hr_viewer
+        });
+
+        const aco = makeACO({
+            sensitivity: "low",
+            tenants: ["🍎"],
+            roles: ["hr_viewer"],
+        });
+
+        const result = canAccess(subject, aco);
+        expect(result.permitted).toBe(false);
+        expect(result.failedCheck).toBe("role");
+    });
+});
+
+// ============================================================================
+// ACO Modification Tests
+// ============================================================================
+
+describe("ACO Modification", () => {
+    it("scen-aco-modify-within-clearance: can modify within clearance", () => {
+        const subject = makeSubject({ clearanceLevel: "moderate" });
+        const currentACO = makeACO({ sensitivity: "low" });
+        const newACO = makeACO({ sensitivity: "moderate" });
+
+        const result = canModifyACO(subject, currentACO, newACO);
+        expect(result.permitted).toBe(true);
+    });
+
+    it("scen-aco-modify-blocked: cannot modify beyond clearance", () => {
+        const subject = makeSubject({ clearanceLevel: "moderate" });
+        const currentACO = makeACO({ sensitivity: "low" });
+        const newACO = makeACO({ sensitivity: "high" }); // Beyond clearance
+
+        const result = canModifyACO(subject, currentACO, newACO);
+        expect(result.permitted).toBe(false);
+        expect(result.reason).toContain("Cannot classify beyond your clearance");
+    });
+
+    it("cannot modify record you cannot access", () => {
+        const subject = makeSubject({ clearanceLevel: "low" });
+        const currentACO = makeACO({ sensitivity: "high" }); // Can't access this
+        const newACO = makeACO({ sensitivity: "low" });
+
+        const result = canModifyACO(subject, currentACO, newACO);
+        expect(result.permitted).toBe(false);
+        expect(result.reason).toContain("no access to current record");
+    });
+});
+
+// ============================================================================
+// Filter By Access Tests
+// ============================================================================
+
+describe("Filter By Access", () => {
+    it("filters array to accessible records", () => {
+        const subject = makeSubject({ clearanceLevel: "moderate" });
+
+        const records = [
+            { id: "1", aco: '{"sensitivity":"public"}' },
+            { id: "2", aco: '{"sensitivity":"low"}' },
+            { id: "3", aco: '{"sensitivity":"moderate"}' },
+            { id: "4", aco: '{"sensitivity":"high"}' },
+        ];
+
+        const filtered = filterByAccess(records, subject);
+        expect(filtered.map((r) => r.id)).toEqual(["1", "2", "3"]);
+    });
+
+    it("handles invalid ACO JSON gracefully", () => {
+        const subject = makeSubject({ clearanceLevel: "high" });
+
+        const records = [
+            { id: "1", aco: '{"sensitivity":"low"}' },
+            { id: "2", aco: "invalid json" },
+            { id: "3", aco: '{"sensitivity":"moderate"}' },
+        ];
+
+        const filtered = filterByAccess(records, subject);
+        expect(filtered.map((r) => r.id)).toEqual(["1", "3"]);
+    });
+});

--- a/rubigo-react/src/lib/access-control/decision.ts
+++ b/rubigo-react/src/lib/access-control/decision.ts
@@ -1,0 +1,155 @@
+/**
+ * Access Decision Algorithm
+ *
+ * Implements the core ABAC decision logic for determining whether
+ * a subject can access an object based on their attributes.
+ */
+
+import type {
+    AccessControlObject,
+    AccessDecision,
+    Subject,
+} from "./types";
+import {
+    parseTenantClearance,
+    sensitivityIndex,
+} from "./types";
+
+/**
+ * Determine if a subject can access an object with the given ACO.
+ *
+ * Access is granted if ALL of the following are true:
+ * 1. Subject has global_admin role (bypasses all checks), OR
+ * 2. Subject clearance >= object sensitivity AND
+ * 3. Subject has access to ALL required tenants at >= object sensitivity AND
+ * 4. Subject has ALL required roles
+ */
+export function canAccess(subject: Subject, aco: AccessControlObject): AccessDecision {
+    // Global admins bypass all checks
+    if (subject.roles.includes("global_admin")) {
+        return { permitted: true };
+    }
+
+    // 1. Sensitivity Check (REQUIRED)
+    const subjectLevel = sensitivityIndex(subject.clearanceLevel);
+    const objectLevel = sensitivityIndex(aco.sensitivity);
+
+    if (subjectLevel < objectLevel) {
+        return {
+            permitted: false,
+            reason: `Insufficient clearance: requires '${aco.sensitivity}', have '${subject.clearanceLevel}'`,
+            failedCheck: "sensitivity",
+        };
+    }
+
+    // 2. Tenant Check (if tenants specified)
+    if (aco.tenants && aco.tenants.length > 0) {
+        for (const tenant of aco.tenants) {
+            const tenantAccess = getSubjectTenantLevel(subject, tenant);
+
+            if (!tenantAccess) {
+                return {
+                    permitted: false,
+                    reason: `No access to tenant '${tenant}'`,
+                    failedCheck: "tenant",
+                };
+            }
+
+            // Subject must have tenant access at or above object sensitivity
+            const tenantLevelIdx = sensitivityIndex(tenantAccess as import("./types").SensitivityLevel);
+            if (tenantLevelIdx < objectLevel) {
+                return {
+                    permitted: false,
+                    reason: `Insufficient tenant clearance for '${tenant}': requires '${aco.sensitivity}', have '${tenantAccess}'`,
+                    failedCheck: "tenant",
+                };
+            }
+        }
+    }
+
+    // 3. Role Check (if roles specified)
+    if (aco.roles && aco.roles.length > 0) {
+        for (const role of aco.roles) {
+            if (!subject.roles.includes(role)) {
+                return {
+                    permitted: false,
+                    reason: `Missing required role: '${role}'`,
+                    failedCheck: "role",
+                };
+            }
+        }
+    }
+
+    return { permitted: true };
+}
+
+/**
+ * Get a subject's clearance level for a specific tenant.
+ * Returns null if the subject has no access to that tenant.
+ */
+function getSubjectTenantLevel(
+    subject: Subject,
+    tenant: string
+): string | null {
+    for (const clearance of subject.tenantClearances) {
+        const parsed = parseTenantClearance(clearance);
+        if (parsed && parsed.tenant === tenant) {
+            return parsed.level;
+        }
+    }
+    return null;
+}
+
+/**
+ * Determine if a subject can modify an ACO from one value to another.
+ *
+ * A subject can modify an ACO if:
+ * 1. They can access records with the current ACO (they can see it)
+ * 2. They can access records with the new ACO (they could see the result)
+ *
+ * This prevents escalation beyond one's own clearance level.
+ */
+export function canModifyACO(
+    subject: Subject,
+    currentACO: AccessControlObject,
+    newACO: AccessControlObject
+): AccessDecision {
+    // Must be able to see the record (current ACO)
+    const currentAccess = canAccess(subject, currentACO);
+    if (!currentAccess.permitted) {
+        return {
+            permitted: false,
+            reason: `Cannot modify: no access to current record`,
+        };
+    }
+
+    // Must be able to see records with the new ACO
+    const newAccess = canAccess(subject, newACO);
+    if (!newAccess.permitted) {
+        return {
+            permitted: false,
+            reason: `Cannot classify beyond your clearance: ${newAccess.reason}`,
+        };
+    }
+
+    return { permitted: true };
+}
+
+/**
+ * Filter an array of records to only those the subject can access.
+ * Assumes each record has an `aco` property.
+ */
+export function filterByAccess<T extends { aco: string }>(
+    records: T[],
+    subject: Subject
+): T[] {
+    return records.filter((record) => {
+        try {
+            const aco: AccessControlObject = JSON.parse(record.aco);
+            return canAccess(subject, aco).permitted;
+        } catch {
+            // If ACO is invalid, deny access
+            return false;
+        }
+    });
+}

--- a/rubigo-react/src/lib/access-control/index.ts
+++ b/rubigo-react/src/lib/access-control/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Access Control Module
+ *
+ * Re-exports all access control types and functions for convenient imports.
+ */
+
+// Types
+export type {
+    AccessControlObject,
+    AccessDecision,
+    ClassificationGuide,
+    ClassificationGuideStatus,
+    SecurityContextObject,
+    SensitivityGuidance,
+    SensitivityLevel,
+    Subject,
+} from "./types";
+
+// Constants
+export {
+    DEFAULT_ACO,
+    SENSITIVITY_ORDER,
+} from "./types";
+
+// Type helpers
+export {
+    formatTenantClearance,
+    parseTenantClearance,
+    sensitivityIndex,
+} from "./types";
+
+// Decision functions
+export {
+    canAccess,
+    canModifyACO,
+    filterByAccess,
+} from "./decision";
+
+// Session resolution
+export {
+    createDevSubject,
+    createTestSubject,
+    resolveSubjectFromPersona,
+} from "./session-resolver";

--- a/rubigo-react/src/lib/access-control/session-resolver.ts
+++ b/rubigo-react/src/lib/access-control/session-resolver.ts
@@ -1,0 +1,134 @@
+/**
+ * Session Resolver
+ *
+ * Resolves the current Subject from authentication context.
+ * For now, this maps from the persona context to a Subject.
+ * Real authentication will be added in a future phase.
+ */
+
+import type { Person } from "@/types/personnel";
+import type { SensitivityLevel, Subject } from "./types";
+
+/**
+ * Resolve a Subject from a persona (for UI context).
+ *
+ * Maps the persona's access control fields to a Subject.
+ * Falls back to defaults if fields are not set.
+ */
+export function resolveSubjectFromPersona(persona: Person): Subject {
+    // Parse clearance level with fallback
+    const clearanceLevel = parseCleananceLevel(persona.clearanceLevel) ?? "low";
+
+    // Parse tenant clearances from JSON
+    const tenantClearances = parseTenantClearances(persona.tenantClearances);
+
+    // Parse roles from JSON
+    const roles = parseRoles(persona.accessRoles, persona.isGlobalAdmin);
+
+    return {
+        id: persona.id,
+        name: persona.name,
+        email: persona.email,
+        clearanceLevel,
+        tenantClearances,
+        roles,
+    };
+}
+
+/**
+ * Create a default Subject for development/testing.
+ * Has global_admin role to bypass all checks.
+ */
+export function createDevSubject(): Subject {
+    return {
+        id: "dev-admin",
+        name: "Development Admin",
+        email: "dev@rubigo.local",
+        clearanceLevel: "high",
+        tenantClearances: [],
+        roles: ["global_admin", "employee"],
+    };
+}
+
+/**
+ * Create a Subject with specific clearance for testing.
+ */
+export function createTestSubject(overrides: Partial<Subject> = {}): Subject {
+    return {
+        id: "test-user",
+        name: "Test User",
+        email: "test@rubigo.local",
+        clearanceLevel: "low",
+        tenantClearances: [],
+        roles: ["employee"],
+        ...overrides,
+    };
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+const VALID_LEVELS: SensitivityLevel[] = ["public", "low", "moderate", "high"];
+
+function parseCleananceLevel(value: unknown): SensitivityLevel | null {
+    if (typeof value === "string" && VALID_LEVELS.includes(value as SensitivityLevel)) {
+        return value as SensitivityLevel;
+    }
+    return null;
+}
+
+function parseTenantClearances(value: unknown): string[] {
+    if (!value) return [];
+
+    // If it's already an array, return it
+    if (Array.isArray(value)) {
+        return value.filter((v) => typeof v === "string");
+    }
+
+    // If it's a JSON string, parse it
+    if (typeof value === "string") {
+        try {
+            const parsed = JSON.parse(value);
+            if (Array.isArray(parsed)) {
+                return parsed.filter((v) => typeof v === "string");
+            }
+        } catch {
+            // Not valid JSON
+        }
+    }
+
+    return [];
+}
+
+function parseRoles(accessRoles: unknown, isGlobalAdmin?: boolean): string[] {
+    const roles: string[] = [];
+
+    // Parse access roles
+    if (accessRoles) {
+        if (Array.isArray(accessRoles)) {
+            roles.push(...accessRoles.filter((v) => typeof v === "string"));
+        } else if (typeof accessRoles === "string") {
+            try {
+                const parsed = JSON.parse(accessRoles);
+                if (Array.isArray(parsed)) {
+                    roles.push(...parsed.filter((v) => typeof v === "string"));
+                }
+            } catch {
+                // Not valid JSON
+            }
+        }
+    }
+
+    // Add global_admin role if isGlobalAdmin flag is set
+    if (isGlobalAdmin && !roles.includes("global_admin")) {
+        roles.push("global_admin");
+    }
+
+    // Ensure at least employee role
+    if (roles.length === 0) {
+        roles.push("employee");
+    }
+
+    return roles;
+}

--- a/rubigo-react/src/lib/access-control/types.ts
+++ b/rubigo-react/src/lib/access-control/types.ts
@@ -1,0 +1,252 @@
+/**
+ * Access Control Types
+ *
+ * Core type definitions for Attribute-Based Access Control (ABAC).
+ * These types are used throughout the platform for authorization decisions.
+ */
+
+// ============================================================================
+// Sensitivity Levels
+// ============================================================================
+
+/**
+ * Sensitivity levels ordered from least to most sensitive.
+ * Subject clearance must be >= object sensitivity to access.
+ */
+export type SensitivityLevel = "public" | "low" | "moderate" | "high";
+
+/**
+ * Sensitivity level ordering for comparison.
+ * Higher index = more sensitive.
+ */
+export const SENSITIVITY_ORDER: readonly SensitivityLevel[] = [
+    "public",
+    "low",
+    "moderate",
+    "high",
+] as const;
+
+/**
+ * Get numeric index for sensitivity comparison.
+ */
+export function sensitivityIndex(level: SensitivityLevel): number {
+    return SENSITIVITY_ORDER.indexOf(level);
+}
+
+// ============================================================================
+// Access Control Object (ACO)
+// ============================================================================
+
+/**
+ * Access Control Object - stored in each record's `aco` column.
+ * Determines WHO can access the record based on their attributes.
+ *
+ * Stored as indexed JSON for pre-query filtering.
+ */
+export interface AccessControlObject {
+    /**
+     * Sensitivity level (REQUIRED, never null).
+     * Subject must have clearance >= this level.
+     */
+    sensitivity: SensitivityLevel;
+
+    /**
+     * Tenant compartments (optional).
+     * If specified, subject must have access to ALL listed tenants
+     * at or above the object's sensitivity level.
+     * Uses fruit emojis: 🍎, 🍌, 🍊, 🍇, 🍓
+     */
+    tenants?: string[];
+
+    /**
+     * Required roles (optional).
+     * If specified, subject must have ALL listed roles.
+     */
+    roles?: string[];
+}
+
+/**
+ * Default ACO for new records.
+ */
+export const DEFAULT_ACO: AccessControlObject = {
+    sensitivity: "low",
+};
+
+// ============================================================================
+// Security Context Object (SCO)
+// ============================================================================
+
+/**
+ * Security Context Object - stored in each record's `sco` column.
+ * Provides audit and context metadata (not used for access decisions).
+ *
+ * Stored as non-indexed JSON.
+ */
+export interface SecurityContextObject {
+    /** ID of user who created/owns this record */
+    ownerId?: string;
+
+    /** Department that owns this data */
+    ownerDepartment?: string;
+
+    /** References to classification guide IDs */
+    classificationGuideRefs?: string[];
+
+    /** Natural language summary and citations for classification */
+    classificationReason?: string;
+
+    /** When security classification was last reviewed (ISO 8601) */
+    lastReviewedAt?: string;
+
+    /** Who last modified the security settings */
+    lastModifiedBy?: string;
+
+    /** Expiration date for sensitivity - auto-declassify (ISO 8601) */
+    expiresAt?: string;
+}
+
+// ============================================================================
+// Subject (Authenticated User)
+// ============================================================================
+
+/**
+ * Subject - represents the authenticated user making a request.
+ * Resolved from the current session/persona.
+ */
+export interface Subject {
+    /** Unique identifier */
+    id: string;
+
+    /** Display name */
+    name: string;
+
+    /** Email address */
+    email: string;
+
+    /**
+     * Clearance level (REQUIRED, never null).
+     * Maximum sensitivity level the subject can access.
+     */
+    clearanceLevel: SensitivityLevel;
+
+    /**
+     * Tenant clearances in format "level:tenant".
+     * Examples: ["moderate:🍎", "high:🍌"]
+     */
+    tenantClearances: string[];
+
+    /**
+     * Roles the subject possesses.
+     * "global_admin" role bypasses all access checks.
+     */
+    roles: string[];
+
+    /** Session ID for request correlation */
+    sessionId?: string;
+
+    /** IP address for audit logging */
+    ipAddress?: string;
+}
+
+// ============================================================================
+// Classification Guide
+// ============================================================================
+
+/**
+ * Classification guide status lifecycle.
+ */
+export type ClassificationGuideStatus = "draft" | "active" | "superseded";
+
+/**
+ * Sensitivity guidance - descriptions for each level.
+ */
+export interface SensitivityGuidance {
+    public: string;
+    low: string;
+    moderate: string;
+    high: string;
+}
+
+/**
+ * Classification Guide - provides English-level descriptions
+ * of how to classify data by sensitivity, tenant, and role.
+ */
+export interface ClassificationGuide {
+    /** Unique identifier (e.g., "CG-HR-001") */
+    id: string;
+
+    /** Version number for tracking changes */
+    version: number;
+
+    /** Human-readable title */
+    title: string;
+
+    /** Guidance for each sensitivity level */
+    sensitivityGuidance: SensitivityGuidance;
+
+    /** Per-tenant guidance (optional) */
+    tenantGuidance?: Record<string, string>;
+
+    /** Per-role guidance (optional) */
+    roleGuidance?: Record<string, string>;
+
+    /** When this guide became effective (ISO 8601) */
+    effectiveDate: string;
+
+    /** Current status */
+    status: ClassificationGuideStatus;
+
+    /** ID of guide that supersedes this one (if superseded) */
+    supersededBy?: string;
+
+    /** When created (ISO 8601) */
+    createdAt: string;
+
+    /** Who created this guide */
+    createdBy: string;
+}
+
+// ============================================================================
+// Access Decision
+// ============================================================================
+
+/**
+ * Result of an access decision.
+ */
+export interface AccessDecision {
+    /** Whether access is permitted */
+    permitted: boolean;
+
+    /** Reason for denial (if not permitted) */
+    reason?: string;
+
+    /** Which check failed (for debugging) */
+    failedCheck?: "sensitivity" | "tenant" | "role";
+}
+
+// ============================================================================
+// Helper Types
+// ============================================================================
+
+/**
+ * Parse tenant clearance string to level and tenant.
+ * @example parseTenantClearance("moderate:🍎") => { level: "moderate", tenant: "🍎" }
+ */
+export function parseTenantClearance(
+    clearance: string
+): { level: SensitivityLevel; tenant: string } | null {
+    const [level, tenant] = clearance.split(":");
+    if (!level || !tenant) return null;
+    if (!SENSITIVITY_ORDER.includes(level as SensitivityLevel)) return null;
+    return { level: level as SensitivityLevel, tenant };
+}
+
+/**
+ * Format tenant clearance from level and tenant.
+ */
+export function formatTenantClearance(
+    level: SensitivityLevel,
+    tenant: string
+): string {
+    return `${level}:${tenant}`;
+}

--- a/rubigo-react/src/types/personnel.ts
+++ b/rubigo-react/src/types/personnel.ts
@@ -27,6 +27,10 @@ export interface Person {
     cellPhone?: string;
     bio?: string;
     isGlobalAdmin?: boolean;
+    // Access control fields
+    clearanceLevel?: string;      // "public" | "low" | "moderate" | "high"
+    tenantClearances?: string;    // JSON array: ["moderate:🍎", "high:🍌"]
+    accessRoles?: string;         // JSON array: ["employee", "manager"]
 }
 
 export interface PersonnelData {


### PR DESCRIPTION
## Summary

Adds the schema foundation for Attribute-Based Access Control (ABAC).

### Changes

- **ACO/SCO columns**: Added to 11 data tables for access control
- **Personnel fields**: clearanceLevel, tenantClearances, accessRoles
- **Classification guides table**: With version history support
- **Decision algorithm**: `canAccess()` with 3 dimensions (sensitivity, tenant, role)
- **Session resolver**: Maps persona to Subject
- **Unit tests**: 24 tests covering all scenarios
- **Requirements**: access-control.toml with 25 scenarios

### Access Control Dimensions

1. **Sensitivity** (required): public → low → moderate → high
2. **Tenant** (optional): Fruit emoji compartments (🍎, 🍌, etc.)
3. **Role** (optional): Required roles for access

---

Work in progress - Phase 1 of ABAC implementation.