### PR TITLE
fix(sidebar): keep parent module expanded when navigating sub-pages

### DIFF
--- a/rubigo-react/rubigo.toml
+++ b/rubigo-react/rubigo.toml
@@ -1,4 +1,4 @@
 [app]
 name = "Rubigo"
-version = "0.9.1"
+version = "0.9.2"
 description = "Enterprise Resource Management Platform"

--- a/rubigo-react/src/components/app-sidebar.tsx
+++ b/rubigo-react/src/components/app-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
@@ -165,6 +165,20 @@ export function AppSidebar({ personnel, version = "0.1.0", variant = "sidebar" }
         }
         return expanded;
     });
+
+    // Keep module expanded when navigating to any of its sub-pages
+    useEffect(() => {
+        for (const module of sidebarModules) {
+            if (module.subPages) {
+                const isPathInModule = module.subPages.some(
+                    (subPage) => pathname === subPage.href || pathname.startsWith(subPage.href + "/")
+                );
+                if (isPathInModule && !expandedModules.has(module.id)) {
+                    setExpandedModules((prev) => new Set(prev).add(module.id));
+                }
+            }
+        }
+    }, [pathname, expandedModules]);
 
     const toggleModule = (moduleId: string) => {
         setExpandedModules((prev) => {

--- a/rubigo-react/src/lib/email-actions.ts
+++ b/rubigo-react/src/lib/email-actions.ts
@@ -139,7 +139,15 @@ export async function getEmails(
             recipientsByEmail.set(r.emailId, names);
         }
 
-        return result.map(({ email, senderName, senderEmail, recipientRead }) => ({
+        // Deduplicate by email ID (can have duplicates when sending to self)
+        const seen = new Set<string>();
+        const dedupedResult = result.filter(({ email }) => {
+            if (seen.has(email.id)) return false;
+            seen.add(email.id);
+            return true;
+        });
+
+        return dedupedResult.map(({ email, senderName, senderEmail, recipientRead }) => ({
             id: email.id,
             threadId: email.threadId,
             subject: email.subject,
@@ -574,7 +582,15 @@ export async function searchEmails(
             )
             .orderBy(desc(emails.sentAt));
 
-        return result.map(({ email, senderName, senderEmail, recipientRead }) => ({
+        // Deduplicate by email ID (can have duplicates when sending to self)
+        const seen = new Set<string>();
+        const dedupedResult = result.filter(({ email }) => {
+            if (seen.has(email.id)) return false;
+            seen.add(email.id);
+            return true;
+        });
+
+        return dedupedResult.map(({ email, senderName, senderEmail, recipientRead }) => ({
             id: email.id,
             threadId: email.threadId,
             subject: email.subject,


### PR DESCRIPTION
## Summary

Fixed the sidebar collapse bug where parent modules would collapse when navigating between sub-pages.

## Changes

- **Sidebar fix**: Added `useEffect` to sync `expandedModules` state with pathname changes
- **Email fix**: Added deduplication to `getEmails`/`searchEmails` to prevent duplicate key warning when sending to self

## Testing

- Pre-push-check: ✅ Passed
- E2E tests: ✅ 124 passed, 20 skipped

Fixes #28