### PR TITLE
chore(deploy): update workflow for Ubuntu/NUC deployment

### DIFF
--- a/.github/workflows/deploy-react.yml
+++ b/.github/workflows/deploy-react.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: self-hosted
+    runs-on: [self-hosted, NUC]
     env:
       BASE: ${{ github.workspace }}/production/rubigo-react
       DATABASE_URL: ${{ github.workspace }}/production/rubigo-react/data/rubigo.db
@@ -41,17 +41,12 @@ jobs:
           cd "$BUILD_DIR"
           bun install --frozen-lockfile
           
-          # Rebuild native modules for current Node.js version
-          # Required because drizzle-kit uses #!/usr/bin/env node shebang and
-          # better-sqlite3 needs to match the runner's Node.js version
-          npm rebuild better-sqlite3
-          
           echo "Dependencies installed in $BUILD_DIR"
 
       - name: Stop current service
         run: |
-          PLIST="$HOME/Library/LaunchAgents/net.kwip.rubigo-react.plist"
-          launchctl unload "$PLIST" 2>/dev/null || true
+          # Stop systemd service (Linux/Ubuntu)
+          systemctl --user stop rubigo-react.service 2>/dev/null || true
           pkill -f "bun.*4430" 2>/dev/null || true
           sleep 2
           echo "Service stopped for build"
@@ -76,16 +71,11 @@ jobs:
           BUILD_DIR="$BASE/builds/${{ github.run_id }}"
           cd "$BUILD_DIR"
           
-          # Apply committed migration files (safe, deterministic)
-          # Use bunx per drizzle-kit docs: https://orm.drizzle.team/docs/kit-overview
-          DATABASE_URL="$DATABASE_URL" bunx drizzle-kit migrate
+          # Apply committed migration files using Bun-native migrator
+          # Uses drizzle-orm/bun-sqlite/migrator instead of drizzle-kit CLI
+          # to avoid Node.js/better-sqlite3 dependency
+          DATABASE_URL="$DATABASE_URL" bun run db:migrate:bun
           
-          # Checkpoint WAL and fully release locks before build
-          # Multiple operations to ensure all connections are closed
-          sqlite3 "$DATABASE_URL" "PRAGMA wal_checkpoint(TRUNCATE);" 2>/dev/null || true
-          sqlite3 "$DATABASE_URL" "PRAGMA journal_mode=DELETE;" 2>/dev/null || true
-          # Wait for any background processes to release file handles
-          sleep 5
           echo "✅ Migrations applied"
 
       - name: Build application
@@ -109,13 +99,12 @@ jobs:
       - name: Deploy (swap symlink and start)
         run: |
           BUILD_DIR="$BASE/builds/${{ github.run_id }}"
-          PLIST="$HOME/Library/LaunchAgents/net.kwip.rubigo-react.plist"
           
           # Swap symlink to new build
           ln -sfn "$BUILD_DIR" "$BASE/current"
           
-          # Start service via launchctl (persists after workflow)
-          launchctl load "$PLIST"
+          # Start service via systemd (Linux/Ubuntu)
+          systemctl --user start rubigo-react.service
           sleep 3
           
           echo "Deployed: $(readlink $BASE/current)"

--- a/rubigo-react.service
+++ b/rubigo-react.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Rubigo React (Next.js on Bun)
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/kstewart/development/rubigo/runner/_work/rubigo/rubigo/production/rubigo-react/current
+ExecStart=/usr/local/bin/bun run start -- -p 4430
+Environment=NODE_ENV=production
+Environment=DATABASE_URL=/home/kstewart/development/rubigo/runner/_work/rubigo/rubigo/production/rubigo-react/data/rubigo.db
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/rubigo-react/package.json
+++ b/rubigo-react/package.json
@@ -15,6 +15,7 @@
     "generate:api": "openapi-typescript ../common/schemas/project.openapi.yaml -o src/types/api.generated.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
+    "db:migrate:bun": "bun src/scripts/migrate.ts",
     "db:push": "drizzle-kit push",
     "db:clean": "bun src/db/clean.ts",
     "db:studio": "drizzle-kit studio",

--- a/rubigo-react/src/scripts/migrate.ts
+++ b/rubigo-react/src/scripts/migrate.ts
@@ -1,0 +1,37 @@
+/**
+ * Bun-native Database Migration Script
+ * 
+ * Uses drizzle-orm/bun-sqlite/migrator instead of drizzle-kit migrate
+ * to avoid the better-sqlite3 Node.js dependency.
+ * 
+ * Usage: DATABASE_URL=/path/to/db.db bun run src/scripts/migrate.ts
+ */
+
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { Database } from "bun:sqlite";
+
+const DB_PATH = process.env.DATABASE_URL || "./rubigo.db";
+
+console.log(`[migrate] Connecting to database: ${DB_PATH}`);
+
+// Create database if it doesn't exist
+const sqlite = new Database(DB_PATH, { create: true });
+
+// Enable WAL mode and busy timeout
+sqlite.exec("PRAGMA journal_mode = WAL;");
+sqlite.exec("PRAGMA busy_timeout = 60000;");
+
+const db = drizzle(sqlite);
+
+console.log("[migrate] Running migrations from ./drizzle...");
+
+try {
+    migrate(db, { migrationsFolder: "./drizzle" });
+    console.log("[migrate] ✅ Migrations complete");
+} catch (error) {
+    console.error("[migrate] ❌ Migration failed:", error);
+    process.exit(1);
+} finally {
+    sqlite.close();
+}


### PR DESCRIPTION
## Summary
- Update workflow to target NUC runner with `[self-hosted, NUC]`
- Replace macOS launchctl with Linux systemctl --user commands
- Add Bun-native migration script to eliminate Node.js dependency
- Update rubigo-react.service for user-level systemd

## Testing
- ✅ Validated on Ubuntu 25.04 NUC
- ✅ Pre-push check passed
- ✅ Health check passed on production