### PR TITLE
chore: bump version to 0.18.1

### DIFF
--- a/rubigo-react/rubigo.toml
+++ b/rubigo-react/rubigo.toml
@@ -1,4 +1,4 @@
 [app]
 name = "Rubigo"
-version = "0.18.0"
+version = "0.18.1"
 description = "Enterprise Resource Management Platform"


### PR DESCRIPTION
Triggering deployment with clean database after removing old rubigo.db